### PR TITLE
remove attr_accessor,  not compatible with OpenStruct

### DIFF
--- a/lib/babili/platform/membership.rb
+++ b/lib/babili/platform/membership.rb
@@ -1,8 +1,6 @@
 module Babili
   module Platform
     class Membership < OpenStruct
-      attr_accessor :room_id
-      attr_accessor :user_id
 
       def self.path
         "platform/rooms/:room_id/users/:user_id/membership"


### PR DESCRIPTION
Need to remove `attr_accessor` on `user_id` and `room_id`.

Due to these `attr_accessor`, `user_id` and `room_id` were not accessible:

```ruby
b = Babili::Platform::Membership.new(room_id: 3, user_id: 4)
b.user_id # return nil
```